### PR TITLE
Clean controllers/concern to prepare for single player

### DIFF
--- a/app/controllers/game_queue_controller.rb
+++ b/app/controllers/game_queue_controller.rb
@@ -42,7 +42,7 @@ class GameQueueController < ApplicationController
 
   def match_for_game
     match_data = @@multiplayer_queue.sort_by { |entry| entry[:time_entered] }.first(2)
-    game = Game.form_game(match_data.first[:deck], match_data.second[:deck])
+    game = MultiplayerGame.form_game(match_data.first[:deck], match_data.second[:deck])
     (@@multiplayer_queue -= match_data) && stream_started_game(game) if game
   end
 

--- a/app/controllers/multiplayer_games_controller.rb
+++ b/app/controllers/multiplayer_games_controller.rb
@@ -1,10 +1,8 @@
 class MultiplayerGamesController < GamesController
   private
 
-  def set_game_and_perspective
-    @game = MultiplayerGame.find(params[:id])
-    # Intended as a plan for spectating perspective but may not be compatible with actioncable turbo streaming
-    @first_person_player = @game.players.find_by(user: current_user) || @game.player_one
-    @opposing_player = @game.opposing_player_of(@first_person_player)
+  def set_game
+    super
+    head(400) unless @game.type == 'MultiplayerGame'
   end
 end

--- a/app/controllers/singleplayer_games_controller.rb
+++ b/app/controllers/singleplayer_games_controller.rb
@@ -7,37 +7,24 @@ class SingleplayerGamesController < GamesController
   end
 
   def submit_mulligan
-    return unless @player.status == 'mulligan'
+    player = @game.players.find_by(user: current_user)
 
-    @player.draw_mulligan_cards if params[:mulligan] # When player requests a new hand
-    @player.update(status: 'default')
-    @game.begin_first_turn
+    return unless player&.status_mulligan?
+
+    player.draw_mulligan_cards if params[:mulligan] # When player requests a new hand
+    player.status_default!
+    @game.touch && @game.begin_first_turn
   end
 
   private
 
-  def set_game_and_perspective
-    @game = SingleplayerGame.find(params[:id])
-    @first_person_player = @game.player_one
-    @opposing_player = @game.player_two
-  end
-
-  def conduct_mulligan
-    # Safety check for if game is in mulligan but player does not have any mulligan cards.
-    return if @first_person_player.cards.in_mulligan.any?
-
-    @first_person_player.draw_mulligan_cards
-  end
-
-  def current_users_turn
-    # In a single player game, it's "always" the real player's turn
-    head(401) unless current_user == @first_person_player.user
-
-    @player = @first_person_player
-  end
-
   def validate_decks_for_game_creation
     @queued_deck = AccountDeck.includes(:archetype, :race).find(params[:deck_one_id])
     redirect_to root_path and return if @queued_deck.card_count != 30
+  end
+
+  def set_game
+    super
+    head(400) unless @game.type == 'SingleplayerGame'
   end
 end


### PR DESCRIPTION
This branch does the following:

- Although 'MultiplayerGame' is the default STI type for a new Game, change the use of Game to MultiplayerGame in `game_queue_controller.rb` to reduce ambiguity.
- Remove unused lines of code from the games controller that persist from before the React framework was implemented and Rails was rendering the view using instance variables.
- Remove unused methods from the cacheable concern (attached to Game) that was used in conjunction with the previously mentioned controller code.
- Enforce the proper URL of /multiplayer_games vs /singleplayer_games by returning a 400 error if you attempt to use the wrong URL for a game that does exist but of the other respective type. (if game 1 is multiplayer, you cannot access it by going to /singleplayer_games/1)
- In preparation for single player games, which only have one human player, the broadcastable methods have had their `players.each` block factored out into it's own method. This also has the advantage of making the code overall more DRY even in the context of multiplayer. This also allows for the double splat operator to shine and take the place of optional arguments.