### PR TITLE
Stylizes deck creation pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'puma', '~> 5.0'
 gem 'importmap-rails'
 
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem 'turbo-rails'
+gem 'turbo-rails', '~> 1.0'
 
 # Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
 gem 'stimulus-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,7 +249,7 @@ DEPENDENCIES
   sprockets-rails
   stimulus-rails
   tailwindcss-rails
-  turbo-rails
+  turbo-rails (~> 1.0)
   tzinfo-data
   web-console
 

--- a/app/controllers/account_decks_controller.rb
+++ b/app/controllers/account_decks_controller.rb
@@ -3,7 +3,7 @@ class AccountDecksController < ApplicationController
   before_action :set_card, only: %i[insert_card remove_card]
 
   def index
-    @account_decks = current_user.account_decks.all
+    @account_decks = current_user.account_decks.includes(:archetype, :race).all
   end
 
   def show; end
@@ -22,7 +22,7 @@ class AccountDecksController < ApplicationController
     else
       puts @account_deck.errors.full_messages
       @races = Race.all
-      @archetypes = Archetype.where.not(name: 'Neutral').all
+      @archetypes = Archetype.where.not(name: 'Neutral').where.not(name: 'Token').where.not(name: 'Barbarian').all
       render :new, status: :unprocessable_entity
     end
   end

--- a/app/controllers/account_decks_controller.rb
+++ b/app/controllers/account_decks_controller.rb
@@ -1,5 +1,5 @@
 class AccountDecksController < ApplicationController
-  before_action :set_current_user_account_deck, only: %i[show insert_card remove_card]
+  before_action :set_current_user_account_deck, only: %i[show insert_card remove_card destroy_all_cards destroy]
   before_action :set_card, only: %i[insert_card remove_card]
 
   def index
@@ -39,7 +39,14 @@ class AccountDecksController < ApplicationController
     @account_deck.destroy_card(@card)
   end
 
-  def destroy; end
+  def destroy
+    @account_deck.destroy
+    redirect_to account_decks_path, status: :see_other
+  end
+
+  def destroy_all_cards
+    @account_deck.destroy_all_cards
+  end
 
   private
 

--- a/app/controllers/singleplayer_games_controller.rb
+++ b/app/controllers/singleplayer_games_controller.rb
@@ -19,6 +19,8 @@ class SingleplayerGamesController < GamesController
   private
 
   def validate_decks_for_game_creation
+    redirect_to root_path and return unless params[:deck_one_id]
+
     @queued_deck = AccountDeck.includes(:archetype, :race).find(params[:deck_one_id])
     redirect_to root_path and return if @queued_deck.card_count != 30
   end

--- a/app/models/account_deck.rb
+++ b/app/models/account_deck.rb
@@ -39,4 +39,9 @@ class AccountDeck < ApplicationRecord
     account_deck_card_references.find_by(card_reference: card).destroy
     touch
   end
+
+  def destroy_all_cards
+    account_deck_card_references.destroy_all
+    touch
+  end
 end

--- a/app/views/account_decks/_account_deck.html.erb
+++ b/app/views/account_decks/_account_deck.html.erb
@@ -1,5 +1,5 @@
-<div class="relative border-2 has-tooltip border-blackish">
-  <section class="absolute mt-4 text-white border-2 rounded tooltip -left-40 border-blackish bg-card-blue">
+<div class="relative border-2 has-tooltip border-blackish  bg-<%=account_deck.archetype.color%>-700 text-white">
+  <section class="absolute text-white border-2 rounded tooltip -left-56 border-blackish bg-card-blue">
     <p>Starting Health: <%=account_deck.race.health_modifier + 30 %></p>
     <p>Starting Gold: <%=account_deck.race.cost_modifier + 1 %></p>
     <p>Starting <%=account_deck.archetype.resource_name%>: <%=account_deck.race.resource_modifier + 1 %></p>
@@ -10,10 +10,10 @@
     <p class="ml-auto"><%=account_deck.card_count%> of 30 Cards </p>
   </div>
 </div>
-<div class="relative overflow-y-scroll max-h-[70vh]">
+<div class="relative max-h-[70vh] overflow-y-scroll">
   <%account_deck.cards.includes(card_constant: %i[archetype keywords]).order(:cost, :id).uniq.each do |card|%>
     <%= button_to remove_card_account_deck_path(id: account_deck&.id, card_id: card.id), class:'w-full border-2 border-blackish flex h-max items-center has-tooltip' do %>
-      <section class="absolute tooltip -left-44">
+      <section class="relative tooltip -left-44">
         <%= render card, cached: true %>
         <div class="w-40 mt-4 text-white border-2 rounded border-blackish bg-card-blue">
           Click a card in your deck to remove it.

--- a/app/views/account_decks/_account_deck.html.erb
+++ b/app/views/account_decks/_account_deck.html.erb
@@ -1,8 +1,8 @@
 <div class="relative border-2 has-tooltip border-blackish">
-  <section class="absolute mt-4 text-white border-2 rounded tooltip -left-56 border-blackish bg-card-blue">
+  <section class="absolute mt-4 text-white border-2 rounded tooltip -left-40 border-blackish bg-card-blue">
     <p>Starting Health: <%=account_deck.race.health_modifier + 30 %></p>
     <p>Starting Gold: <%=account_deck.race.cost_modifier + 1 %></p>
-    <p>Starting <%=account_deck.archetype.resource_name%>: <%=account_deck.race.health_modifier + 1 %></p>
+    <p>Starting <%=account_deck.archetype.resource_name%>: <%=account_deck.race.resource_modifier + 1 %></p>
   </section>
   <h1 class="text-4xl font-bold"><%=account_deck.name%></h1>
   <div class="flex flex-row items-end">
@@ -10,10 +10,10 @@
     <p class="ml-auto"><%=account_deck.card_count%> of 30 Cards </p>
   </div>
 </div>
-<div class="relative">
+<div class="relative overflow-y-scroll max-h-[70vh]">
   <%account_deck.cards.includes(card_constant: %i[archetype keywords]).order(:cost, :id).uniq.each do |card|%>
     <%= button_to remove_card_account_deck_path(id: account_deck&.id, card_id: card.id), class:'w-full border-2 border-blackish flex h-max items-center has-tooltip' do %>
-      <section class="absolute tooltip -left-48">
+      <section class="absolute tooltip -left-44">
         <%= render card, cached: true %>
         <div class="w-40 mt-4 text-white border-2 rounded border-blackish bg-card-blue">
           Click a card in your deck to remove it.
@@ -22,14 +22,16 @@
       <div class="w-10 h-10 text-3xl text-center text-white border-2 border-amber-600 bg-amber-500">
         <%=card.cost%>
       </div>
-      <div class="w-10 h-10 text-3xl text-center text-white bg-red-500 border-2 border-red-600">
-        <%=card.attack%>
-      </div>
-      <div class="w-10 h-10 text-3xl text-center text-white border-2 border-lime-600 bg-lime-500 ">
-        <%=card.health%>
-      </div>
-      <div class="pl-3 text-2xl">
-        <%=truncate(card.card_constant.name, length:10)%>
+      <%if card.card_type =="PartyCard"%>
+        <div class="w-10 h-10 text-3xl text-center text-white bg-red-500 border-2 border-red-600">
+          <%=card.attack%>
+        </div>
+        <div class="w-10 h-10 text-3xl text-center text-white border-2 border-lime-600 bg-lime-500 ">
+          <%=card.health%>
+        </div>
+      <%end%>
+      <div class="pl-3 text-2xl whitespace-nowrap">
+        <%=truncate(card.card_constant.name, length:18)%>
       </div>
       <div class="w-10 h-10 ml-auto text-3xl text-center text-white border-2 border-cyan-600 bg-cyan-500">
         <%=account_deck.account_deck_card_references.where(card_reference: card).size%>

--- a/app/views/account_decks/index.html.erb
+++ b/app/views/account_decks/index.html.erb
@@ -1,7 +1,23 @@
-<div>
+<div class="ml-[10%] basis-1/5 top-0 flex-none mr-5">
   <h1 class="text-4xl font-bold">List of my decks:</h1>
-  <%@account_decks.each do |deck|%>
-    <%=link_to deck.name, deck%> <br>
-  <% end %>
-  <%= link_to "Create A Deck", new_account_deck_path %>
+  <div class="my-4">
+    <%@account_decks.each do |deck|%>
+      <%=link_to deck do%>
+        <div class="relative border-2 has-tooltip bg-<%=deck.archetype.color%>-700 border-blackish text-white mb-2">
+          <section class="absolute text-white border-2 rounded tooltip -right-64 w-60 border-blackish bg-card-blue">
+            <p>Starting Health: <%=deck.race.health_modifier + 30 %></p>
+            <p>Starting Gold: <%=deck.race.cost_modifier + 1 %></p>
+            <p>Starting <%=deck.archetype.resource_name%>: <%=deck.race.resource_modifier + 1 %></p>
+          </section>
+          <h1 class="text-4xl font-bold"><%=deck.name%></h1>
+          <div class="flex flex-row items-end">
+            <h2><%=deck.race.name%> <%=deck.archetype.name%></h2>
+            <p class="ml-auto"><%=deck.card_count%> of 30 Cards </p>
+          </div>
+        </div>
+      <%end%>
+    <% end %>
+  </div>
+  <%= link_to "Create A Deck", new_account_deck_path, class:'bg-card-blue text-white px-2 py-3 mt-4 rounded-xl mt-8' %>
+  <%= link_to "Back to Home", root_path, class:'bg-card-blue text-white px-2 py-3 mt-4 rounded-xl mt-8' %>
 </div>

--- a/app/views/account_decks/new.html.erb
+++ b/app/views/account_decks/new.html.erb
@@ -1,20 +1,20 @@
 <%=form_with model:@account_deck do |form| %>
-  <div>
+  <div class="mt-4 ml-4">
     <h1 class="text-4xl font-bold">Creating A Deck:</h1>
-    <p>Name:</p>
+    <p>Deck Name:</p>
     <%= form.text_field :name %>
-    <p>Choose your race:</p>
+    <p>Choose your race: (This gives you a small racial bonus)</p>
     <%@races.each do |race|%>
       <div>
         <%= form.radio_button :race_id, race.id %> <%=race.name%>: <%=race.description%>
       </div>
     <% end %>
-    <p>Choose your archetype:</p>
+    <p>Choose your archetype: (This changes the cards you can put in your deck)</p>
     <%@archetypes.each do |archetype|%>
       <div>
         <%= form.radio_button :archetype_id, archetype.id %><%=archetype.name%>: <%=archetype.description%>
       </div>
     <% end %>
-    <%= form.submit %>
+    <%= form.submit class:'bg-card-blue text-white px-2 py-3 mt-4 rounded-xl mt-8' %>
   </div>
 <% end %>

--- a/app/views/account_decks/show.html.erb
+++ b/app/views/account_decks/show.html.erb
@@ -1,6 +1,9 @@
-<article class="ml-[10%] basis-1/5 top-0 flex-none mr-5">
-  <%= button_to "Clear all cards", destroy_all_cards_account_deck_path(@account_deck), form: { data: {turbo_method: :post, turbo_confirm: "Are you sure you want to clear all cards?" }}, class:"bg-card-blue text-white px-2 py-3 mt-4 rounded-xl" %>
-  <%= button_to "Delete this deck", @account_deck, method: :delete, form: { data: { turbo_confirm: "Are you sure you want to delete this deck?" }}, class:"bg-card-blue text-white px-2 py-3 mt-4 rounded-xl" %>
+<article class="ml-[15%]  basis-1/5 top-0 flex-none mr-5">
+  <div class="flex flex-row gap-x-2">
+    <%= button_to "Clear all cards", destroy_all_cards_account_deck_path(@account_deck), form: { data: {turbo_method: :post, turbo_confirm: "Are you sure you want to clear all cards?" }}, class:"bg-card-blue text-white px-2 py-3 mt-4 rounded-xl" %>
+    <%= button_to "Delete this deck", @account_deck, method: :delete, form: { data: { turbo_confirm: "Are you sure you want to delete this deck?" }}, class:"bg-card-blue text-white px-2 py-3 mt-4 rounded-xl" %>
+    <%= link_to  "My decks", account_decks_path, {class: "bg-card-blue text-white px-2 py-3 mt-4 rounded-xl"} %>
+  </div>
   <div class="w-full mt-4">
     <%= turbo_stream_from @account_deck %>
     <div id="<%=dom_id(@account_deck)%>" class="max-w-full">

--- a/app/views/account_decks/show.html.erb
+++ b/app/views/account_decks/show.html.erb
@@ -1,7 +1,11 @@
-<article class="ml-[10%] mt-24 basis-1/4 mr-5">
-  <%= turbo_stream_from @account_deck %>
-  <div id="<%=dom_id(@account_deck)%>" class="max-w-full">
-    <%= render @account_deck %>
+<article class="ml-[10%] basis-1/5 top-0 flex-none mr-5">
+  <%= button_to "Clear all cards", destroy_all_cards_account_deck_path(@account_deck), form: { data: {turbo_method: :post, turbo_confirm: "Are you sure you want to clear all cards?" }}, class:"bg-card-blue text-white px-2 py-3 mt-4 rounded-xl" %>
+  <%= button_to "Delete this deck", @account_deck, method: :delete, form: { data: { turbo_confirm: "Are you sure you want to delete this deck?" }}, class:"bg-card-blue text-white px-2 py-3 mt-4 rounded-xl" %>
+  <div class="w-full mt-4">
+    <%= turbo_stream_from @account_deck %>
+    <div id="<%=dom_id(@account_deck)%>" class="max-w-full">
+      <%= render @account_deck %>
+    </div>
   </div>
 </article>
 <section>

--- a/app/views/card_references/_card_reference.html.erb
+++ b/app/views/card_references/_card_reference.html.erb
@@ -3,7 +3,7 @@
   <div class="absolute z-10 w-10 h-10 text-3xl text-center text-white border-2 rounded-full border-<%=bubbleColor%>-600 bg-<%=bubbleColor%>-500 -top-2 -left-2">
     <%=card_reference.cost%>
   </div>
-  <div class="text-right text-md absolute top-0 inset-x-0 inset-x-0 border-2 rounded border-blackish bg-<%=card_reference.archetype.color%>-700">
+  <div class="text-right text-sm absolute top-0 inset-x-0 inset-x-0 border-b-2 rounded-b-md border-blackish select-none pointer-events-none w-full pr-1 bg-<%=card_reference.archetype.color%>-700">
     <%=card_reference.name%>
   </div>
   <%if card_reference.card_type != "SpellCard"%>

--- a/app/views/card_references/_card_reference.html.erb
+++ b/app/views/card_references/_card_reference.html.erb
@@ -1,16 +1,19 @@
-<div class="relative z-50 w-40 text-white border-2 border-blackish rounded h-60">
-  <div class="absolute z-10 w-10 h-10 text-3xl text-center text-white border-2 rounded-full border-amber-600 bg-amber-500 -top-2 -left-2">
+<%bubbleColor = card_reference.card_type == "PartyCard" ? 'amber' : 'sky' %>
+<div class="relative z-50 w-40 text-white border-2 rounded border-blackish h-60">
+  <div class="absolute z-10 w-10 h-10 text-3xl text-center text-white border-2 rounded-full border-<%=bubbleColor%>-600 bg-<%=bubbleColor%>-500 -top-2 -left-2">
     <%=card_reference.cost%>
   </div>
   <div class="text-right text-md absolute top-0 inset-x-0 inset-x-0 border-2 rounded border-blackish bg-<%=card_reference.archetype.color%>-700">
     <%=card_reference.name%>
   </div>
-  <div class="absolute z-10 w-10 h-10 pb-1 mt-1 text-3xl text-center text-white bg-red-500 border-2 border-red-600 rounded-full -bottom-2 -left-2">
-    <%=card_reference.attack%>
-  </div>
-  <div class="absolute z-10 w-10 h-10 pb-1 mt-1 text-3xl text-center text-white border-2 rounded-full border-lime-600 bg-lime-500 -bottom-2 -right-2">
-    <%=card_reference.health%>
-  </div>
+  <%if card_reference.card_type != "SpellCard"%>
+    <div class="absolute z-10 w-10 h-10 pb-1 mt-1 text-3xl text-center text-white bg-red-500 border-2 border-red-600 rounded-full -bottom-2 -left-2">
+      <%=card_reference.attack%>
+    </div>
+    <div class="absolute z-10 w-10 h-10 pb-1 mt-1 text-3xl text-center text-white border-2 rounded-full border-lime-600 bg-lime-500 -bottom-2 -right-2">
+      <%=card_reference.health%>
+    </div>
+  <%end%>
   <div class="text-center text-xs absolute bottom-2 inset-x-0 border-2 rounded border-blackish bg-<%=card_reference.archetype.color%>-700 h-24">
     <%card_reference.keywords.each do |k|%>
       <p><strong><%=k.class%></strong>: <%=k.body_text%></p>

--- a/app/views/card_references/index.html.erb
+++ b/app/views/card_references/index.html.erb
@@ -1,6 +1,6 @@
 <%=turbo_frame_tag id="cards_collection" do %>
-  <h1 class="text-4xl font-bold">List of all <%="#{params[:name]} "%>Party Cards</h1>
-  <section class="flex flex-row flex-wrap gap-x-5">
+  <h1 class="text-4xl font-bold">List of all <%="#{params[:name]} "%>Cards</h1>
+  <section class="flex flex-row flex-wrap gap-x-5 gap-y-2">
     <%@card_references.each do |card|%>
       <%= button_to insert_card_account_deck_path(id: @account_deck&.id, card_id: card.id) do %>
         <%= render card, cached: true %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -8,7 +8,9 @@
       <%= f.collection_select :deck_id, @decks.order(:name),:id, :name, include_blank: false %>
       <%= f.submit "Queue this deck!", class: "bg-card-blue text-white px-2 py-3 rounded-xl", id:"queue-button" %>
     <% end %>
-    <%= link_to "My most recent game", @game, {data: {turbo: false}, class: "bg-card-blue text-white px-1 py-3 rounded-xl w-max mt-3"}%>
+    <%if @game%>
+      <%= link_to "My most recent game", @game, {data: {turbo: false}, class: "bg-card-blue text-white px-1 py-3 rounded-xl w-max mt-3"}%>
+    <%end%>
   </div>
   <h2 class="mt-6 text-2xl font-bold">Singleplayer Mode:</h2>
   <div class="flex flex-col">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   get 'battlecry/:id/targets', to: 'battlecries#targets', as: 'battlecry_targets'
   resources :account_decks do
     member do
+      post 'destroy_all_cards'
       post 'insert_card'
       post 'remove_card'
     end


### PR DESCRIPTION
This branch makes account deck related pages easier to navigate by:
- Fixing bugs related to spell cards appearing to be party cards in the collection list
- Adding navigation buttons between home, decks, and deck editing
- Showing deck information on the index page for decks, previously just name
- Making buttons more clear that they are buttons
- Adding overflow scroll to long deck lists
- Adding a button to delete a deck
- Adding a button to clear all cards from a deck